### PR TITLE
Add support for ARIA2-RPC token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,7 @@ Fields of configure file:
 + :code:`BGMI_TMP_PATH`: just a temporary path
 + :code:`ARIA2_PATH`: the aria2c binary path
 + :code:`ARIA2_RPC_URL`: aria2c deamon RPC url
++ :code:`ARIA2_RPC_TOKEN`: aria2c deamon RPC token
 + :code:`BGMI_LX_PATH`: path of xunlei-lixian binary
 + :code:`DANMAKU_API_URL`: url of danmaku api
 + :code:`CONVER_URL`: url of bangumi's cover

--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -13,7 +13,7 @@ except ImportError:
 __all__ = ('BANGUMI_MOE_URL', 'BGMI_PATH', 'DB_PATH', 'BGMI_SAVE_PATH',
            'BGMI_LX_PATH', 'DOWNLOAD_DELEGATE', 'CONFIG_FILE_PATH',
            'DETAIL_URL', 'FETCH_URL', 'IS_PYTHON3', 'MAX_PAGE',
-           'BGMI_TMP_PATH', 'ARIA2_PATH', 'ARIA2_RPC_URL',
+           'BGMI_TMP_PATH', 'ARIA2_PATH', 'ARIA2_RPC_URL', 'ARIA2_RPC_TOKEN',
            'DANMAKU_API_URL', 'COVER_URL', 'LANG', 'WGET_PATH')
 
 __readonly__ = ('BGMI_PATH', 'DB_PATH', 'CONFIG_FILE_PATH',
@@ -116,6 +116,7 @@ BGMI_LX_PATH = os.path.join(BGMI_PATH, 'bgmi-lx')
 # aria2
 ARIA2_PATH = '/usr/bin/aria2c'
 ARIA2_RPC_URL = 'http://localhost:6800/rpc'
+ARIA2_RPC_TOKEN = ''
 
 # temp path
 BGMI_TMP_PATH = os.path.join(BGMI_PATH, 'tmp')

--- a/bgmi/services.py
+++ b/bgmi/services.py
@@ -6,7 +6,7 @@ import subprocess
 from tempfile import NamedTemporaryFile
 
 import bgmi.config
-from bgmi.config import BGMI_LX_PATH, BGMI_PATH, BGMI_TMP_PATH, ARIA2_PATH, ARIA2_RPC_URL, WGET_PATH
+from bgmi.config import BGMI_LX_PATH, BGMI_PATH, BGMI_TMP_PATH, ARIA2_PATH, ARIA2_RPC_URL, ARIA2_RPC_TOKEN, WGET_PATH
 from bgmi.utils.utils import print_warning, print_info, print_error, print_success
 from bgmi.models import Download, STATUS_DOWNLOADED, STATUS_NOT_DOWNLOAD, STATUS_DOWNLOADING
 
@@ -121,7 +121,7 @@ class Aria2DownloadRPC(DownloadService):
         super(Aria2DownloadRPC, self).__init__(**kwargs)
 
     def download(self):
-        self.server.aria2.addUri([self.torrent], {"dir": self.save_path})
+        self.server.aria2.addUri(ARIA2_RPC_TOKEN, [self.torrent], {"dir": self.save_path})
         print_info('Add torrent into the download queue, the file will be saved at {0}'.format(self.save_path))
 
     @staticmethod
@@ -151,7 +151,7 @@ class Aria2DownloadRPC(DownloadService):
                     params = (0, 1000)
                 else:
                     params = ()
-                data = server.aria2[method](*params)
+                data = server.aria2[method](ARIA2_RPC_TOKEN, *params)
                 if data:
                     print_warning('RPC {0}:'.format(method), indicator=False)
                 for row in data:


### PR DESCRIPTION
Add support for ARIA2-RPC token, format example: `ARIA2_RPC_TOKEN = "token:fuck_hackers"`
(Not been tested when aria2 doesn't have token set
ref: https://aria2.github.io/manual/en/html/aria2c.html#rpc-authorization-secret-token