### PR TITLE
fix ' Error: cannot use a string pattern on a bytes-like object' in services.py

### DIFF
--- a/bgmi/services.py
+++ b/bgmi/services.py
@@ -136,7 +136,7 @@ class Aria2DownloadRPC(DownloadService):
         command = [ARIA2_PATH, '--version']
         p = subprocess.Popen(command, env={'PATH': '/usr/local/bin:/usr/bin:/bin',
                              'HOME': os.environ.get('HOME', '/tmp')}, stdout=subprocess.PIPE)
-        version = re.findall('aria2 version (.*)', p.stdout.read().splitlines()[0])
+        version = re.findall('aria2 version (.*)', str(p.stdout.read()).splitlines()[0])
         if version:
             Aria2DownloadRPC.old_version = version[0] < '1.18.4'
         else:


### PR DESCRIPTION
在ubuntu和windows上获取到的stdout.read()是一个a bytes-like object,用re匹配的时候会报错
`Error: cannot use a string pattern on a bytes-like object`


(吐槽一下这个报错..太难找到到底在哪出错了....每次都是把try excerpt改成if True才找到的..