### PR TITLE
bug fix for losing colomn in script.scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,8 @@ Bangumi Script is located at :code:`BGMI_PATH/script`, inherited :code:`ScriptBa
     import requests
     import urllib
 
-    from bgmi.script import ScriptBase, parse_episode
+    from bgmi.utils import parse_episode
+    from bgmi.script import ScriptBase
     from bgmi.utils import print_error
     from bgmi.config import IS_PYTHON3
 
@@ -300,7 +301,8 @@ Another example:
     import requests
     from bs4 import BeautifulSoup as bs
 
-    from bgmi.script import ScriptBase, parse_episode
+    from bgmi.utils import parse_episode
+    from bgmi.script import ScriptBase
     from bgmi.utils import print_error
     from bgmi.config import IS_PYTHON3
 

--- a/bgmi/script.py
+++ b/bgmi/script.py
@@ -1,61 +1,17 @@
 # coding=utf-8
 from __future__ import print_function, unicode_literals
 
-import re
-import os
-import imp
 import glob
+import imp
+import os
 import time
 import traceback
 
-from bgmi.models import STATUS_UPDATED, STATUS_FOLLOWED
-from bgmi.utils import print_success, print_warning, print_info
 from bgmi.config import SCRIPT_PATH
 from bgmi.download import download_prepare
+from bgmi.models import STATUS_UPDATED, STATUS_FOLLOWED
 from bgmi.models import Script
-
-
-FETCH_EPISODE_ZH = re.compile("第?\s?(\d{1,3})\s?[話话集]")
-FETCH_EPISODE_WITH_BRACKETS = re.compile('[【\[](\d+)\s?(?:END)?[】\]]')
-FETCH_EPISODE_ONLY_NUM = re.compile('^([\d]{2,})$')
-FETCH_EPISODE_RANGE = re.compile('[\d]{2,}\s?-\s?([\d]{2,})')
-FETCH_EPISODE_OVA_OAD = re.compile('([\d]{2,})\s?\((?:OVA|OAD)\)]')
-FETCH_EPISODE_WITH_VERSION = re.compile('[【\[](\d+)\s? *v\d(?:END)?[】\]]')
-FETCH_EPISODE = (
-    FETCH_EPISODE_ZH, FETCH_EPISODE_WITH_BRACKETS, FETCH_EPISODE_ONLY_NUM,
-    FETCH_EPISODE_RANGE,
-    FETCH_EPISODE_OVA_OAD, FETCH_EPISODE_WITH_VERSION)
-
-
-def parse_episode(episode_title):
-    """
-    parse episode from title
-
-    :param episode_title: episode title
-    :type episode_title: str
-    :return: episode of this title
-    :rtype: int
-    """
-
-    _ = FETCH_EPISODE_ZH.findall(episode_title)
-    if _ and _[0].isdigit():
-        return int(_[0])
-
-    _ = FETCH_EPISODE_WITH_BRACKETS.findall(episode_title)
-    if _ and _[0].isdigit():
-        return int(_[0])
-
-    _ = FETCH_EPISODE_WITH_VERSION.findall(episode_title)
-    if _ and _[0].isdigit():
-        return int(_[0])
-
-    for split_token in ['【', '[', ' ']:
-        for i in episode_title.split(split_token):
-            for regexp in FETCH_EPISODE:
-                match = regexp.findall(i)
-                if match and match[0].isdigit():
-                    return int(match[0])
-    return 0
+from bgmi.utils import print_success, print_warning, print_info
 
 
 class ScriptRunner(object):

--- a/bgmi/sql.py
+++ b/bgmi/sql.py
@@ -50,7 +50,8 @@ CREATE_TABLE_SCRIPT = '''CREATE TABLE IF NOT EXISTS scripts (
           id INTEGER PRIMARY KEY  AUTOINCREMENT,
           bangumi_name TEXT UNIQUE NOT NULL,
           episode INTEGER DEFAULT 0,
-          status INTEGER DEFAULT 1
+          status INTEGER DEFAULT 1,
+          updated_time INTEGER DEFAULT 0
         )'''
 
 CLEAR_TABLE_ = 'DELETE  FROM {}'

--- a/bgmi/utils/utils.py
+++ b/bgmi/utils/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import print_function, unicode_literals
 import os
+import re
 import sys
 import time
 import platform
@@ -202,3 +203,46 @@ def check_update(mark=True):
                 return update()
         except ValueError:
             pass
+
+
+FETCH_EPISODE_ZH = re.compile("第?\s?(\d{1,3})\s?[話话集]")
+FETCH_EPISODE_WITH_BRACKETS = re.compile('[【\[](\d+)\s?(?:END)?[】\]]')
+FETCH_EPISODE_ONLY_NUM = re.compile('^([\d]{2,})$')
+FETCH_EPISODE_RANGE = re.compile('[\d]{2,}\s?-\s?([\d]{2,})')
+FETCH_EPISODE_OVA_OAD = re.compile('([\d]{2,})\s?\((?:OVA|OAD)\)]')
+FETCH_EPISODE_WITH_VERSION = re.compile('[【\[](\d+)\s? *v\d(?:END)?[】\]]')
+FETCH_EPISODE = (
+    FETCH_EPISODE_ZH, FETCH_EPISODE_WITH_BRACKETS, FETCH_EPISODE_ONLY_NUM,
+    FETCH_EPISODE_RANGE,
+    FETCH_EPISODE_OVA_OAD, FETCH_EPISODE_WITH_VERSION)
+
+
+def parse_episode(episode_title):
+    """
+    parse episode from title
+
+    :param episode_title: episode title
+    :type episode_title: str
+    :return: episode of this title
+    :rtype: int
+    """
+
+    _ = FETCH_EPISODE_ZH.findall(episode_title)
+    if _ and _[0].isdigit():
+        return int(_[0])
+
+    _ = FETCH_EPISODE_WITH_BRACKETS.findall(episode_title)
+    if _ and _[0].isdigit():
+        return int(_[0])
+
+    _ = FETCH_EPISODE_WITH_VERSION.findall(episode_title)
+    if _ and _[0].isdigit():
+        return int(_[0])
+
+    for split_token in ['【', '[', ' ']:
+        for i in episode_title.split(split_token):
+            for regexp in FETCH_EPISODE:
+                match = regexp.findall(i)
+                if match and match[0].isdigit():
+                    return int(match[0])
+    return 0

--- a/bgmi/website/base.py
+++ b/bgmi/website/base.py
@@ -23,7 +23,7 @@ else:
 
 
 class BaseWebsite(object):
-    parse_episode = parse_episode
+    parse_episode = staticmethod(parse_episode)
     def search(self, keyword='', count=1, filter_=None):
         if not filter_:
             filter_ = '(.*)'

--- a/bgmi/website/base.py
+++ b/bgmi/website/base.py
@@ -8,11 +8,12 @@ import string
 import time
 from collections import defaultdict
 from itertools import chain
+
 import bgmi.config
 from bgmi.config import MAX_PAGE
 from bgmi.models import Bangumi, Filter, Subtitle, STATUS_FOLLOWED, STATUS_UPDATED
 from bgmi.script import ScriptRunner
-from bgmi.utils import (print_warning, print_info,
+from bgmi.utils import (parse_episode, print_warning, print_info,
                         test_connection, get_terminal_col, GREEN, YELLOW, COLOR_END)
 
 if bgmi.config.IS_PYTHON3:
@@ -21,51 +22,8 @@ else:
     _unicode = unicode
 
 
-FETCH_EPISODE_ZH = re.compile("第?\s?(\d{1,3})\s?[話话集]")
-FETCH_EPISODE_WITH_BRACKETS = re.compile('[【\[](\d+)\s?(?:END)?[】\]]')
-FETCH_EPISODE_ONLY_NUM = re.compile('^([\d]{2,})$')
-FETCH_EPISODE_RANGE = re.compile('[\d]{2,}\s?-\s?([\d]{2,})')
-FETCH_EPISODE_OVA_OAD = re.compile('([\d]{2,})\s?\((?:OVA|OAD)\)]')
-FETCH_EPISODE_WITH_VERSION = re.compile('[【\[](\d+)\s? *v\d(?:END)?[】\]]')
-FETCH_EPISODE = (
-    FETCH_EPISODE_ZH, FETCH_EPISODE_WITH_BRACKETS, FETCH_EPISODE_ONLY_NUM,
-    FETCH_EPISODE_RANGE,
-    FETCH_EPISODE_OVA_OAD, FETCH_EPISODE_WITH_VERSION)
-
-
 class BaseWebsite(object):
-    # todo : 00-11这种识别错误
-    @staticmethod
-    def parse_episode(episode_title):
-        """
-        parse episode from title
-
-        :param episode_title: episode title
-        :type episode_title: str
-        :return: episode of this title
-        :rtype: int
-        """
-
-        _ = FETCH_EPISODE_ZH.findall(episode_title)
-        if _ and _[0].isdigit():
-            return int(_[0])
-
-        _ = FETCH_EPISODE_WITH_BRACKETS.findall(episode_title)
-        if _ and _[0].isdigit():
-            return int(_[0])
-
-        _ = FETCH_EPISODE_WITH_VERSION.findall(episode_title)
-        if _ and _[0].isdigit():
-            return int(_[0])
-
-        for split_token in ['【', '[', ' ']:
-            for i in episode_title.split(split_token):
-                for regexp in FETCH_EPISODE:
-                    match = regexp.findall(i)
-                    if match and match[0].isdigit():
-                        return int(match[0])
-        return 0
-
+    parse_episode = parse_episode
     def search(self, keyword='', count=1, filter_=None):
         if not filter_:
             filter_ = '(.*)'

--- a/script_example.py
+++ b/script_example.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 from __future__ import print_function, unicode_literals
 
-import re
 import json
-import requests
+import re
 import urllib
 
-from bgmi.script import ScriptBase, parse_episode
-from bgmi.utils import print_error
-from bgmi.config import IS_PYTHON3
+import requests
 
+from bgmi.config import IS_PYTHON3
+from bgmi.script import ScriptBase
+from bgmi.utils import print_error, parse_episode
 
 if IS_PYTHON3:
     unquote = urllib.parse.unquote


### PR DESCRIPTION
```python3
  File "bgmi\controllers.py", line 211, in cal
    website.bangumi_calendar(force_update=ret.force_update, today=ret.today, save=not ret.no_save)
  File "bgmi\website\base.py", line 130, in bangumi_calendar
    patch_list = runner.get_models_dict()
  File "bgmi\script.py", line 48, in get_models_dict
    return [dict(script.Model()) for script in self.scripts if script.bangumi_name is not None]
  File "bgmi\script.py", line 113, in __init__
    s.save()
  File "bgmi\models.py", line 352, in save
    self.cursor.execute(sql, _v)
sqlite3.OperationalError: table scripts has no column named updated_time
```
应该是[sql.py](https://github.com/RicterZ/BGmi/blob/master/bgmi/sql.py#L53)的
```python
CREATE_TABLE_SCRIPT = '''CREATE TABLE IF NOT EXISTS scripts (
          id INTEGER PRIMARY KEY  AUTOINCREMENT,
          bangumi_name TEXT UNIQUE NOT NULL,
          episode INTEGER DEFAULT 0,
          status INTEGER DEFAULT 1
        )'''
```
漏掉了`updated_time INTEGER DEFAULT 0`
(居然不是直接复制的`CREATE_TABLE_FOLLOWED`,难道这是个feature?)